### PR TITLE
adds sorting queries to GET /api/articles endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -213,6 +213,60 @@ describe("/api/articles", () => {
           expect(articles).toBeSortedBy("created_at", { descending: true });
         });
     });
+    test("responds with a status 200 and articles order given by sort_by query column name, defaults to created_at descending", () => {
+      return request(app)
+        .get("/api/articles?sort_by=author")
+        .expect(200)
+        .then(({ body: { articles } }) => {
+          expect(articles).toHaveLength(13);
+          expect(articles).toBeSortedBy("author", {
+            descending: true,
+          });
+        });
+    });
+    test("responds with a status 400 and error message for invalid sort_by query value", () => {
+      return request(app)
+        .get("/api/articles?sort_by=not_a_valid_column")
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("Invalid query");
+        });
+    });
+  });
+  test("responds with a status 400 and error message for incorrect sort_by query parameter", () => {
+    return request(app)
+      .get("/api/articles?sorted_incorrect=title")
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Invalid query");
+      });
+  });
+  test("responds with a status 200 and takes an order query, which can be set to asc or desc (defaulting to descending)", () => {
+    return request(app)
+      .get("/api/articles?sort_by=title&order=asc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toHaveLength(13);
+        expect(articles).toBeSortedBy("title", {
+          ascending: true,
+        });
+      });
+  });
+  test("responds with a status 400 and error message for invalid order query value", () => {
+    return request(app)
+      .get("/api/articles?order=not_a_valid_query_value")
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Invalid query");
+      });
+  });
+  test("responds with a status 400 and error message for incorrect order query parameter", () => {
+    return request(app)
+      .get("/api/articles?sort_by=title&invalid_param=asc")
+      .expect(400)
+      .then(({ body: { msg } }) => {
+        expect(msg).toBe("Invalid query");
+      });
   });
 });
 describe("/api/articles/:article_id/comments", () => {

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -8,14 +8,20 @@ const {
   removeCommentById,
   checkCommentExists,
   selectUsers,
+  checkValidQueryParams,
 } = require("../models");
 
 exports.getArticles = (request, response, next) => {
-  selectArticles()
+  checkValidQueryParams(request.query)
+    .then(() => {
+      const { sort_by, order } = request.query;
+      return selectArticles(sort_by, order);
+    })
     .then((articles) => {
       response.status(200).send({ articles });
     })
     .catch((err) => {
+      console.log(err);
       next(err);
     });
 };

--- a/models/index.js
+++ b/models/index.js
@@ -8,6 +8,7 @@ const {
   removeCommentById,
   checkCommentExists,
   selectUsers,
+  checkValidQueryParams,
 } = require("./articles.model");
 const { selectTopics } = require("./topics.models");
 
@@ -22,4 +23,5 @@ module.exports = {
   removeCommentById,
   checkCommentExists,
   selectUsers,
+  checkValidQueryParams,
 };


### PR DESCRIPTION
The endpoint accepts the following queries:

sort_by, which sorts the articles by any valid column (defaults to the created_at date).
order, which can be set to asc or desc for ascending or descending (defaults to descending).
